### PR TITLE
fix(Api Service): stop ApolloServer instance after executing graphql …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Expose entry ID as argument of "create" mutation instead of automatic ID generation
 - Check ID of entry before executing an update, delete mutation
 
+### Fixed
+- [#32](https://github.com/commitspark/graphql-api/issues/32) Fix memory leak triggered by API calls
+
 ## [0.8.0] - 2023-06-17
 ### Fixed
 - [#26](https://github.com/commitspark/graphql-api/issues/26) Querying optional reference field with null value causes

--- a/src/app/api.service.ts
+++ b/src/app/api.service.ts
@@ -50,6 +50,8 @@ export class ApiService {
       },
     )
 
+    await apolloServer.stop()
+
     return {
       ref: context.getCurrentRef(),
       data:


### PR DESCRIPTION
This PR fixes a memory leak in the API Service that eventually causes the node server to crash.

The solution is to call `apolloServer.stop` before returning a response since a new server instance is created on each request. 

Before fix:
<img width="1165" alt="before-fix" src="https://github.com/commitspark/graphql-api/assets/32719539/8c695f75-9a1e-4695-ab77-e2f36b2b8fc4">

After fix:
<img width="1159" alt="with-fix" src="https://github.com/commitspark/graphql-api/assets/32719539/e4f7a1ea-3553-4c62-9146-1836d6d4498a">
